### PR TITLE
Added UPDATE_CONTEXT control word for updating watson context in botium scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/runtime": "^7.2.0",
     "async": "^2.6.1",
     "debug": "^3.1.0",
+    "jsonpath": "^1.0.1",
     "lodash": "^4.17.11",
     "watson-developer-cloud": "^3.12.0"
   }


### PR DESCRIPTION
Allows test creator to alter the watson context between utterances to mimic orchestrated middleware behaviour (API data, feature toggles, etc)

Totally open to tweaks or changes to this PR, looking for feedback on concept and overall goal.


This example PR uses [JSONPath](https://github.com/json-path/JsonPath) for easily expressing JSON path traversal (for updating).

Some working examples (leveraging this feature):

```
Prove timezone updates work

#me
UPDATE_CONTEXT $.timezone America/New_York string

#bot
{ 
    "timezone": "Australia/New_York"
}
```

```
Set boolean to context
#me
UPDATE_CONTEXT $.system.initialized false boolean
```

```
Set integer to context
UPDATE_CONTEXT $.EscalationCounter 0 integer
```
