### PR TITLE
Add Support for Authentication via Bearer Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ _Default: "2018-09-20"_
 ### WATSON_APIKEY *
 IAM API Key for IBM Watson - see [here](https://cloud.ibm.com/docs/services/watson/getting-started-iam.html) how to create it for your IBM Watson account. Either the IAM API Key or the Service credentials (see below) are required.
 
+### WATSON_BEARER *
+
+IBM Watson instances using the [Cloud Pak For Data Platform](https://cloud.ibm.com/apidocs/cloud-pak-data#getauthorizationtoken) do not have IAM API Keys, but can instead be authenticated using the bearer token found within the service instance details.
+
 ### WATSON_USER * and WATSON_PASSWORD *
 Service credentials for your IBM Watson instance - see [here](https://console.bluemix.net/docs/services/watson/getting-started-credentials.html#service-credentials-for-watson-services) how to create them for your IBM Watson account.
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = {
         label: 'Bearer token for IBM Watson CP4D',
         type: 'secret',
         required: false
-      }
+      },
       {
         name: 'WATSON_WELCOME_MESSAGE',
         label: 'Trigger Welcome Message',
@@ -124,7 +124,6 @@ module.exports = {
                 opts.authenticator = new BearerTokenAuthenticator({
                   bearerToken: caps.WATSON_BEARER
                 })
-              }
               } else {
                 opts.authenticator = new BasicAuthenticator({
                   username: caps.WATSON_USER,

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 const AssistantV1 = require('ibm-watson/assistant/v1')
-const { IamAuthenticator, BasicAuthenticator } = require('ibm-watson/auth')
+const { IamAuthenticator, BasicAuthenticator, BearerTokenAuthenticator } = require('ibm-watson/auth')
 const BotiumConnectorWatson = require('./src/connector')
 const { importHandler, importArgs, importWatsonLogConvos, importWatsonLogIntents } = require('./src/watsonintents')
 const { exportHandler, exportArgs } = require('./src/watsonintents')
@@ -54,6 +54,12 @@ module.exports = {
         required: false
       },
       {
+        name: 'WATSON_BEARER',
+        label: 'Bearer token for IBM Watson CP4D',
+        type: 'secret',
+        required: false
+      }
+      {
         name: 'WATSON_WELCOME_MESSAGE',
         label: 'Trigger Welcome Message',
         type: 'string',
@@ -104,7 +110,7 @@ module.exports = {
         type: 'query',
         required: false,
         query: async (caps) => {
-          if (caps && ((caps.WATSON_USER && caps.WATSON_PASSWORD) || caps.WATSON_APIKEY) && caps.WATSON_URL) {
+          if (caps && ((caps.WATSON_USER && caps.WATSON_PASSWORD) || caps.WATSON_APIKEY || caps.WATSON_BEARER) && caps.WATSON_URL) {
             return new Promise((resolve, reject) => {
               const opts = {
                 url: caps.WATSON_URL,
@@ -114,6 +120,11 @@ module.exports = {
                 opts.authenticator = new IamAuthenticator({
                   apikey: caps.WATSON_APIKEY
                 })
+              } else if (caps.WATSON_BEARER) {
+                opts.authenticator = new BearerTokenAuthenticator({
+                  bearerToken: caps.WATSON_BEARER
+                })
+              }
               } else {
                 opts.authenticator = new BasicAuthenticator({
                   username: caps.WATSON_USER,

--- a/src/connector.js
+++ b/src/connector.js
@@ -75,7 +75,7 @@ class BotiumConnectorWatson {
           if (this.caps[Capabilities.WATSON_APIKEY]) {
             Object.assign(opts, { authenticator: new IamAuthenticator({ apikey: this.caps[Capabilities.WATSON_APIKEY] }) })
           } else if (this.caps[Capabilities.WATSON_BEARER]) {
-            Object.assign(opts, { authenticator: new BearerTokenAuthenticator({ apikey: this.caps[Capabilities.WATSON_BEARER] }) })
+            Object.assign(opts, { authenticator: new BearerTokenAuthenticator({ bearerToken: this.caps[Capabilities.WATSON_BEARER] }) })
           } else {
             Object.assign(opts, {
               username: this.caps[Capabilities.WATSON_USER],

--- a/src/connector.js
+++ b/src/connector.js
@@ -5,7 +5,7 @@ const randomize = require('randomatic')
 const _ = require('lodash')
 const AssistantV1 = require('ibm-watson/assistant/v1')
 const AssistantV2 = require('ibm-watson/assistant/v2')
-const { IamAuthenticator } = require('ibm-watson/auth')
+const { IamAuthenticator, BearerTokenAuthenticator } = require('ibm-watson/auth')
 const debug = require('debug')('botium-connector-watson')
 const { getWorkspace, createWorkspace, waitWorkspaceAvailable } = require('./helpers')
 
@@ -16,6 +16,7 @@ const Capabilities = {
   WATSON_HTTP_PROXY_PORT: 'WATSON_HTTP_PROXY_PORT',
   WATSON_VERSION: 'WATSON_VERSION',
   WATSON_APIKEY: 'WATSON_APIKEY',
+  WATSON_BEARER: 'WATSON_BEARER',
   WATSON_USER: 'WATSON_USER',
   WATSON_PASSWORD: 'WATSON_PASSWORD',
   WATSON_WORKSPACE_ID: 'WATSON_WORKSPACE_ID',
@@ -44,9 +45,9 @@ class BotiumConnectorWatson {
     this.caps = Object.assign({}, Defaults, this.caps)
 
     if (!this.caps[Capabilities.WATSON_URL]) throw new Error('WATSON_URL capability required')
-    if (!this.caps[Capabilities.WATSON_APIKEY]) {
-      if (!this.caps[Capabilities.WATSON_USER]) throw new Error('WATSON_USER capability required (or use WATSON_APIKEY)')
-      if (!this.caps[Capabilities.WATSON_PASSWORD]) throw new Error('WATSON_PASSWORD capability required (or use WATSON_APIKEY)')
+    if (!this.caps[Capabilities.WATSON_APIKEY] && !this.caps[Capabilities.WATSON_BEARER]) {
+      if (!this.caps[Capabilities.WATSON_USER]) throw new Error('WATSON_USER capability required (or use WATSON_APIKEY or WATSON_BEARER)')
+      if (!this.caps[Capabilities.WATSON_PASSWORD]) throw new Error('WATSON_PASSWORD capability required (or use WATSON_APIKEY or WATSON_BEARER)')
     }
     if (!this.caps[Capabilities.WATSON_VERSION]) throw new Error('WATSON_VERSION capability required')
 
@@ -73,6 +74,8 @@ class BotiumConnectorWatson {
           }
           if (this.caps[Capabilities.WATSON_APIKEY]) {
             Object.assign(opts, { authenticator: new IamAuthenticator({ apikey: this.caps[Capabilities.WATSON_APIKEY] }) })
+          } else if (this.caps[Capabilities.WATSON_BEARER]) {
+            Object.assign(opts, { authenticator: new BearerTokenAuthenticator({ apikey: this.caps[Capabilities.WATSON_BEARER] }) })
           } else {
             Object.assign(opts, {
               username: this.caps[Capabilities.WATSON_USER],


### PR DESCRIPTION
I am using botium for a project at work where we are on a Cloud Pak For Data account, which [does not support IAM API keys](https://cloud.ibm.com/apidocs/cloud-pak-data#getauthorizationtoken). Instead, users must supply their bearer token that can be found in their service instance details page.

This PR adds the option of specifying a WATSON_BEARER entry in the config, which instantiates a [BearerTokenAuthenticator](https://github.com/IBM/node-sdk-core/blob/master/auth/authenticators/bearer-token-authenticator.ts) instead of the IAMAuthenticator that is the default.

(The `ibm-watson` module also appears to provide a [CP4D Authenticator](https://github.com/IBM/node-sdk-core/blob/master/auth/authenticators/cloud-pak-for-data-authenticator.ts), which could be helpful as well)