### PR TITLE
Bugfix: watson filter is called "filter" not watsonfilter

### DIFF
--- a/src/watsonintents.js
+++ b/src/watsonintents.js
@@ -195,7 +195,7 @@ const importWatsonLogs = async ({ caps, watsonfilter }, conversion) => {
     workspaceId: driver.caps.WATSON_WORKSPACE_ID,
     pageLimit: 1000,
     sort: 'request_timestamp',
-    watsonfilter
+    filter: watsonfilter
   }
   while (hasMore) {
     debug(`Watson workspace gettings logs page: ${pageParams.cursor}`)


### PR DESCRIPTION
Hi According to documentation the filter is called "filter", not watsonfilter. Please see: https://cloud.ibm.com/apidocs/assistant-v1#listlogs